### PR TITLE
Add Windows compatibility to locateThemeTemplate method

### DIFF
--- a/src/TheEventsCalendar.php
+++ b/src/TheEventsCalendar.php
@@ -48,6 +48,13 @@ class TheEventsCalendar
     protected function locateThemeTemplate(string $template): string
     {
         $plugin_path = trailingslashit(dirname( \TRIBE_EVENTS_FILE ));
+
+        // Convert any backslashes to forward slashes for Windows compatibility.
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $plugin_path = str_replace('\\', '/', $plugin_path);
+            $template = str_replace('\\', '/', $template);
+        }
+
         $themeTemplate = 'tribe/events/v2' . str_replace($plugin_path . 'src/views/v2', '', $template);
 
         return locate_template($this->sageFinder->locate($themeTemplate));


### PR DESCRIPTION
This allows the plugin to work in a Windows environment, where the file paths may be a mix of forward and backslashes.