### PR TITLE
Add sage view paths for tribe events path list

### DIFF
--- a/src/TheEventsCalendar.php
+++ b/src/TheEventsCalendar.php
@@ -22,6 +22,49 @@ class TheEventsCalendar
     }
 
     /**
+     * Override The Events Calendar's V2 Views
+     *
+     * Based on:
+     * @link https://gist.github.com/cliffordp/39e68939132bd0f483e0111972165455
+     * @link https://theeventscalendar.com/knowledgebase/k/custom-templates-for-the-updated-calendar-views/
+     *
+     * @see  \Tribe__Template::tribe_template_theme_path_list()
+     *
+     * @param array $folders Array of data for loading locations.
+     *
+     * @return array
+     */
+    public function tribeTemplateThemePathList($folders)
+    {
+        $sage_tribe_base_path = resource_path('views/tribe/');
+
+        $folders['sage_tec'] = [
+            'id'       => 'sage_tec',
+            'priority' => 5,
+            'path'     => $sage_tribe_base_path . 'events',
+        ];
+
+        $folders['sage_tec_pro'] = [
+            'id'       => 'sage_tec_pro',
+            'priority' => 5,
+            'path'     => $sage_tribe_base_path . 'pro',
+        ];
+
+        $folders['sage_et'] = [
+            'id'       => 'sage_et',
+            'priority' => 5,
+            'path'     => $sage_tribe_base_path . 'tickets',
+        ];
+
+        $folders['sage_ce'] = [
+            'id'       => 'sage_ce',
+            'priority' => 5,
+            'path'     => $sage_tribe_base_path . 'community',
+        ];
+        return $folders;
+    }
+
+    /**
      * Support blade templates for the main template include.
      */
     public function templateInclude(string $template): string

--- a/src/TheEventsCalendarServiceProvider.php
+++ b/src/TheEventsCalendarServiceProvider.php
@@ -37,6 +37,7 @@ class TheEventsCalendarServiceProvider extends ServiceProvider
     {
         $tribeEvents = $this->app['tribe_events'];
 
+        add_filter('tribe_template_theme_path_list', [$tribeEvents, 'tribeTemplateThemePathList'], 10, 1);
         add_filter( 'template_include', [$tribeEvents, 'templateInclude'], 51);
     }
 }


### PR DESCRIPTION
This adds the sage theme resources view path to the paths list for extending themes in Tribe events. 

Based on the other PR [here](https://github.com/supermundano/sage-the-events-calendar/pull/3) but I found that the v2 in the path was redundant, and didn't want the output buffering that was added later on.  