### PR TITLE
Switch to the filter used in tribe for internal template files

### DIFF
--- a/src/TheEventsCalendarServiceProvider.php
+++ b/src/TheEventsCalendarServiceProvider.php
@@ -38,6 +38,6 @@ class TheEventsCalendarServiceProvider extends ServiceProvider
         $tribeEvents = $this->app['tribe_events'];
 
         add_filter('tribe_template_theme_path_list', [$tribeEvents, 'tribeTemplateThemePathList'], 10, 1);
-        add_filter( 'template_include', [$tribeEvents, 'templateInclude'], 51);
+        add_filter( 'tribe_template_file', [$tribeEvents, 'templateInclude'], 51);
     }
 }


### PR DESCRIPTION
I found that the filter that was used `template_include` wasn't fired for every template in v2, in fact it only ran for `default-template`

Using `tribe_template_file` with the same signature and logic worked though. It seems to be an updated internal filter for the new theme system.