### PR TITLE
Fix "creation of dynamic property" notice

### DIFF
--- a/src/TheEventsCalendar.php
+++ b/src/TheEventsCalendar.php
@@ -12,6 +12,10 @@ use function Roots\resource_path;
 
 class TheEventsCalendar
 {
+    private $sageFinder;
+    private $fileFinder;
+    private $app;
+
     public function __construct(
         ViewFinder $sageFinder,
         FileViewFinder $fileFinder,


### PR DESCRIPTION
Example notice:

```
PHP Deprecated:  Creation of dynamic property Supermundano\Sage\TheEventsCalendar\TheEventsCalendar::$sageFinder is deprecated.
```